### PR TITLE
Replace backslashes by single quotes

### DIFF
--- a/monitoring/systree.md
+++ b/monitoring/systree.md
@@ -29,6 +29,6 @@ The feature and the interval can be changed at runtime using the `vmq-admin` scr
 Examples:
 
 ```text
-mosquitto_sub -t \$SYS/<node-name>/\# -u <username> -P <password> -d
+mosquitto_sub -t '$SYS/<node-name>/#' -u <username> -P <password> -d
 ```
 


### PR DESCRIPTION
I think replacing the backslashes which have to be escaped in the shell by single quotes makes the example more legible.