### PR TITLE
Update docker.md docker inspect to include name

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -33,7 +33,7 @@ This allows a newly started container to automatically join a VerneMQ cluster. A
 docker run -e "DOCKER_VERNEMQ_DISCOVERY_NODE=<IP-OF-VERNEMQ1>" --name vernemq2 -d erlio/docker-vernemq
 ```
 
-\(Note, you can find the IP of a docker container using `docker inspect | grep \"IPAddress\"`\).
+\(Note, you can find the IP of a docker container using `docker inspect <CONTAINER_NAME> | grep \"IPAddress\"`\).
 
 ## Checking cluster status
 


### PR DESCRIPTION
Change: `docker inspect` to `docker inspect <CONTAINER_NAME>`

It might be clearer to show that the user needs to put the CONTAINER_NAME after the `docker inspect` command.

```
$ docker inspect --help

Usage:	docker inspect [OPTIONS] NAME|ID [NAME|ID...]
```