### PR TITLE
Add examples to clarify testing shared subscriptions. 

### DIFF
--- a/configuration/shared_subscriptions.md
+++ b/configuration/shared_subscriptions.md
@@ -22,3 +22,23 @@ shared_subscription_policy = prefer_local
 
 When a messages is being delivered to subscribers of a shared subscription, the message will be delivered to an online subscriber if possible, otherwise the message will be delivered to an offline subscriber.
 
+## Examples
+
+**Subscriptions**
+*Note: When subscribing to a shared topic, make sure to escape the `$` 
+```bash
+mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname
+mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname/#
+```
+So, for dash on ubuntu bionic
+```bash
+mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t \$share/group/topicname
+mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t \$share/group/topicname/#
+```
+
+**Publishing**
+*Note: When publishing to a shared topic, do not include the phrase **$share/group/** as part of the publish topic name*
+```bash
+mosquito_pub -h mqtt.example.io -p 1883 -t topicname -m "This is a test message"
+mosquito_pub -h mqtt.example.io -p 1883 -t topicname/group1 -m "This is a test message"
+```

--- a/configuration/shared_subscriptions.md
+++ b/configuration/shared_subscriptions.md
@@ -26,11 +26,8 @@ When a messages is being delivered to subscribers of a shared subscription, the 
 
 **Subscriptions**
 *Note: When subscribing to a shared topic, make sure to escape the `$`*
-```bash
-mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname
-mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname/#
-```
-So, for dash on ubuntu bionic
+
+So, for dash or bash shells 
 ```bash
 mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t \$share/group/topicname
 mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t \$share/group/topicname/#

--- a/configuration/shared_subscriptions.md
+++ b/configuration/shared_subscriptions.md
@@ -25,7 +25,7 @@ When a messages is being delivered to subscribers of a shared subscription, the 
 ## Examples
 
 **Subscriptions**
-*Note: When subscribing to a shared topic, make sure to escape the `$` 
+*Note: When subscribing to a shared topic, make sure to escape the `$`*
 ```bash
 mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname
 mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t $share/group/topicname/#
@@ -37,7 +37,7 @@ mosquitto_sub -h mqtt.example.io -p 1883 -q 2 -t \$share/group/topicname/#
 ```
 
 **Publishing**
-*Note: When publishing to a shared topic, do not include the phrase **$share/group/** as part of the publish topic name*
+*Note: When publishing to a shared topic, do not include the prefix `$share/group/` as part of the publish topic name*
 ```bash
 mosquito_pub -h mqtt.example.io -p 1883 -t topicname -m "This is a test message"
 mosquito_pub -h mqtt.example.io -p 1883 -t topicname/group1 -m "This is a test message"


### PR DESCRIPTION
Add examples to clarify testing shared subscriptions. Specifically running under dash on Ubuntu bionic.