### PR TITLE
Changes topic name all to open_to_all for readability

### DIFF
--- a/configuration/file-auth.md
+++ b/configuration/file-auth.md
@@ -177,25 +177,25 @@ VerneMQ currently doesn't cancel active subscriptions in case the ACL file revok
 # ACL for anonymous clients
 topic bar
 topic write foo
-topic read all
+topic read open_to_all
 
 
 # ACL for user 'john'
 user john
 topic foo
 topic read baz
-topic write all
+topic write open_to_all
 ```
 
 Anonymous users are allowed to
 
 * publish & subscribe to topic bar.
 * publish to topic foo.
-* subscribe to topic all.
+* subscribe to topic open_to_all.
 
 User john is allowed to
 
 * publish & subscribe to topic foo.
 * subscribe to topic baz.
-* publish to topic all.
+* publish to topic open_to_all.
 


### PR DESCRIPTION
Hey, the topic name here `all` made me confused that it's granting access to all topics as opposed to intention. Keeping it as a draft PR to initiate thoughts.