### PR TITLE
Fix link to Shared Subscription page from deprecated Consumer session balancing

### DIFF
--- a/configuration/balancing.md
+++ b/configuration/balancing.md
@@ -5,7 +5,7 @@ description: MQTT consumers can share and loadbalance a topic subscription.
 # Consumer session balancing
 
 {% hint style="warning" %}
-Consumer session balancing has been deprecated and will be removed in VerneMQ 2.0. Use [Shared Subscriptions]() instead.
+Consumer session balancing has been deprecated and will be removed in VerneMQ 2.0. Use [Shared Subscriptions](configuration/shared_subscriptions) instead.
 {% endhint %}
 
 Sometimes consumers get overwhelmed by the number of messages they receive. VerneMQ can load balance between multiple consumer instances subscribed to the same topic with the same ClientId.


### PR DESCRIPTION
Consumer session balancing feature is deprecated but the link to the replacing feature Shared Subscription is empty.

Adding the link.