### PR TITLE
Fix link to HTTP listener configuration

### DIFF
--- a/monitoring/status.md
+++ b/monitoring/status.md
@@ -4,7 +4,7 @@ description: The VerneMQ Status Page
 
 # Status Page
 
-VerneMQ comes with a built-in Status Page that is enabled by default and is available on `http://localhost:8888/status`, see [HTTP listeners](../configuring-vernemq/http-listeners.md).
+VerneMQ comes with a built-in Status Page that is enabled by default and is available on `http://localhost:8888/status`, see [HTTP listeners](../configuration/http-listeners.md).
 
 The Status Page is a simple overview of the cluster and the individual nodes in the cluster as seen below. Note that while the Status Page is running on each node of the cluster, it's enough to look at one of them to get a quick status of your cluster.
 


### PR DESCRIPTION
The documentation contains a link to the description of how to configure HTTP listeners. This link pointed to a non-existing page. This commit solves the wrong link by replacing it with the correct link.