### PR TITLE
Adds docs explaining how to create multiple users in same password file

### DIFF
--- a/configuration/file-auth.md
+++ b/configuration/file-auth.md
@@ -102,6 +102,7 @@ Add multiple user to the existing password file :
 
 ```text
 vmq-passwd /etc/vernemq/vmq.passwd bob
+vmq-passwd /etc/vernemq/vmq.passwd john
 ```
 
 

--- a/configuration/file-auth.md
+++ b/configuration/file-auth.md
@@ -64,6 +64,10 @@ vmq-passwd -U passwordfile
 
 > Creates a new password file. If the file already exists, it will be overwritten.
 
+` `
+
+> When run with no option, It will create a new password and append it to the password file if exists. Does not overwrite the existing file
+
 `-D`
 
 > Deletes the specified user from the password file.
@@ -93,6 +97,13 @@ Delete a user from a password file
 ```text
 vmq-passwd -D /etc/vernemq/vmq.passwd henry
 ```
+
+Add multiple user to the existing password file :
+
+```text
+vmq-passwd /etc/vernemq/vmq.passwd bob
+```
+
 
 **Acknowledgements**
 

--- a/configuration/file-auth.md
+++ b/configuration/file-auth.md
@@ -64,9 +64,9 @@ vmq-passwd -U passwordfile
 
 > Creates a new password file. If the file already exists, it will be overwritten.
 
-` `
+`<no option>`
 
-> When run with no option, It will create a new password and append it to the password file if exists. Does not overwrite the existing file
+> When run with no option, It will create a new user and password and append it to the password file if exists. Does not overwrite the existing file
 
 `-D`
 


### PR DESCRIPTION
I felt current docs doesn't make it intuitive enough to explain that the vmq_passwd can easily create multiple users. 

The current docs give the impression that the only supported flags are -c -cf -D -U. 