### PR TITLE
Describe max_request_line_length, max_header_value_length for websocket

### DIFF
--- a/configuration/websockets.md
+++ b/configuration/websockets.md
@@ -20,3 +20,13 @@ Keep in mind that you'll use MQTT-over-WebSocket, so you will need a Javascript 
 
 You won't be able to open WebSocket connections on a base URL, always add the `/mqtt` path.
 
+When establishing a WebSocket connection to the VerneMQ MQTT broker, the process begins with an HTTP connection that is then upgraded to WebSocket. This upgrade mechanism means the broker's ability to accept connections can be influenced by HTTP listener settings.
+
+In certain scenarios, such as when connecting from a frontend application, the size of HTTP request headers (including cookies) can exceed the default maximum allowed by VerneMQ. This can lead to a 'HTTP 431 Request Header Fields Too Large' error, preventing the connection from being established.
+
+This behavior is configurable in the `vernemq.conf` file to accommodate larger headers:
+
+```text
+listener.http.default.max_request_line_length=32000
+listener.http.default.max_header_value_length=32000
+```


### PR DESCRIPTION
Add extra info for websocket connection after experiencing https://github.com/vernemq/vernemq/issues/2267
- Mention already exposed listener.http.default.max_request_line_length setting
- Describe [proposed](https://github.com/vernemq/vernemq/pull/2272) listener.http.default.max_header_value_length 