### PR TITLE
Updated SSL setting for postgres database

### DIFF
--- a/configuration/db-auth.md
+++ b/configuration/db-auth.md
@@ -134,7 +134,7 @@ vmq_diversity.postgres.password_hash_method = crypt
 In case your Postgresql database requires SSL, you'll have to tell the plugin: 
 
 ```text 
-vmq_diversity.ssl.enabled = on
+vmq_diversity.postgres.ssl = on
 ```
 
 Consult the `vernemq.conf` file for more info about additional options: 


### PR DESCRIPTION
I think this might have changed? I could not spot it in [vmq_diversity.schema](https://github.com/vernemq/vernemq/blob/main/apps/vmq_diversity/priv/vmq_diversity.schema)

```
2025-11-19T09:19:11.811806+00:00 [debug] Adding Defaults
2025-11-19T09:19:11.813047+00:00 [debug] Right Hand Side Substitutions
2025-11-19T09:19:11.813129+00:00 [debug] Applying Datatypes
2025-11-19T09:19:11.822546+00:00 [error] You've tried to set vmq_diversity.ssl.enabled, but there is no setting with that name.
```